### PR TITLE
Fix README examples of Login/Logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ siftClient.SendMessage("1", "4", "some subject", "hello ");
 
 ```
 
-###Login
+###Login (Success)
 
 ```csharp
 
@@ -235,11 +235,19 @@ siftClient.Login("1", "u4ryixmnkwxm1aviiyq4yez1", true);
 
 ```
 
-###Logout
+###Login (Failure)
 
 ```csharp
 
 siftClient.Login("1", "u4ryixmnkwxm1aviiyq4yez1", false);
+
+```
+
+###Logout
+
+```csharp
+
+siftClient.Logout("1");
 
 ```
 


### PR DESCRIPTION
This just fixes the example documentation for Login/Logout.
Currently it uses the failed login code for Logout and does not have a real Logout example.