### PR TITLE
Add Adyen field to PaymentGateway

### DIFF
--- a/src/SiftScienceNet/Events/PaymentGateway.cs
+++ b/src/SiftScienceNet/Events/PaymentGateway.cs
@@ -10,7 +10,8 @@ namespace SiftScienceNet.Events
         Braintree,
         Paypal,
         AmazonPayments,
-        Authorizenet        
+        Authorizenet,
+        Adyen        
     }
 
     public class PaymentGatewayConverter : JsonConverter
@@ -33,6 +34,9 @@ namespace SiftScienceNet.Events
 
             if (paymentGateway == PaymentGateway.Authorizenet)
                 writer.WriteValue("$authorizenet");
+
+            if (paymentGateway == PaymentGateway.Adyen)
+                writer.WriteValue("$adyen");
 
         }
 


### PR DESCRIPTION
Hello,
I am using your library for SiftScience and I like it a lot!

Since I need to use it for Adyen payments, it would be really cool to do it in this library since it is already supported by SiftScience ( https://siftscience.com/resources/references/events-api#complex-fields-payment ) .
Please let me know if you have any question and thank you a lot for your job.