### PR TITLE
Add last_label to SiftScore

### DIFF
--- a/src/SiftScienceNet/Scores/SiftScore.cs
+++ b/src/SiftScienceNet/Scores/SiftScore.cs
@@ -21,6 +21,15 @@ namespace SiftScienceNet.Scores
         public Details Details { get; set; }
     }
 
+    public class LatestLabel
+    {
+        [JsonProperty("is_bad")]
+        public bool IsBad { get; set; }
+
+        [JsonProperty("time")]
+        public int Time { get; set; }
+    }
+
     public class SiftScore
     {
         [JsonProperty("user_id")]
@@ -34,6 +43,9 @@ namespace SiftScienceNet.Scores
 
         [JsonProperty("status")]
         public int Status { get; set; }
+
+        [JsonProperty("latest_label")]
+        public LatestLabel LatestLabel { get; set; }
 
         [JsonProperty("error_message")]
         public string ErrorMessage { get; set; }


### PR DESCRIPTION
Just a little bit to include the "bad/not bad" bit in the user's latest_label api response.
Works nice because if the user is not labeled, SiftScore.LatestLabel will be null.

I don't mean to just drop little pieces at a time. (I added the 2 new PaymentGateways just 2 days ago.) We are just starting to use SiftScience, and I'm adding to your library the things we are using as we need them. I am brand new to GitHub, so I'm not sure of the etiquette. If you prefer I hold off until I get a goodly amount, just let me know. Otherwise, I will just trickle them as I make them.

Thanks again!