### PR TITLE
PaymentMethod verification_status should be nullable, because this pr…

### DIFF
--- a/src/SiftScienceNet/Events/Account.cs
+++ b/src/SiftScienceNet/Events/Account.cs
@@ -24,7 +24,7 @@ namespace SiftScienceNet.Events
         [JsonProperty("$referrer_user_id")]
         public string ReferrerUserId { get; set; }
 
-        [JsonProperty("payment_methods")]
+        [JsonProperty("$payment_methods")]
         public List<PaymentMethod> PaymentMethods { get; set; }
 
         [JsonProperty("$billing_address")]

--- a/src/SiftScienceNet/Events/PaymentMethod.cs
+++ b/src/SiftScienceNet/Events/PaymentMethod.cs
@@ -23,7 +23,7 @@ namespace SiftScienceNet.Events
         public string CvvResultCode { get; set; }
 
         [JsonProperty("$verification_status")]
-        public Status VerificationStatus { get; set; }
+        public Status? VerificationStatus { get; set; }
 
         [JsonProperty("$routing_number")]
         public string RoutingNumber { get; set; }


### PR DESCRIPTION
…operty cannot be sent for cash payment type

@mathieukempe here's another small change. Publish to nuget whenever you get to it? Thanks again :)