### PR TITLE
Add GetLegacyScore method to SiftClient

### DIFF
--- a/src/SiftScienceNet/Globals.cs
+++ b/src/SiftScienceNet/Globals.cs
@@ -13,5 +13,6 @@ namespace SiftScienceNet
         public const string EventsWithScoreEndpoint = EventsEndpoint + "?return_score=true";
         public const string LabelsEndpoint = Authority + "/v204/users/{0}/labels";
         public const string ScoresEndpoint = Authority + "/v204/score/{0}/?api_key={1}";
-    }    
+        public const string LegacyScoreEndpoint = Authority + "/v204/score/{0}/?abuse_types=legacy&api_key={1}";
+    }
 }

--- a/src/SiftScienceNet/Scores/ScoreResponse.cs
+++ b/src/SiftScienceNet/Scores/ScoreResponse.cs
@@ -7,7 +7,7 @@ using System.Runtime.Serialization;
 
 namespace SiftScienceNet.Scores
 {
-    public class ScoreResponse
+    public class ScoreResponseBase
     {
         [JsonProperty("user_id")]
         public string UserId { get; set; }
@@ -16,14 +16,29 @@ namespace SiftScienceNet.Scores
         [JsonProperty("scores")]
         public Dictionary<AbuseType, SiftScore> Scores { get; set; }
 
-        [JsonProperty("latest_label")]
-        public LatestLabel LatestLabel { get; set; }
-
         [JsonProperty("error_message")]
         public string ErrorMessage { get; set; }
 
         [JsonProperty("status")]
         public int Status { get; set; }
+    }
+
+    public class LegacyScoreResponse : ScoreResponseBase
+    {
+        [JsonProperty("latest_labels")]
+        public LatestLabel LatestLabels { get; set; }
+
+        [JsonProperty("score")]
+        public double Score { get; set; }
+
+        [JsonProperty("reasons")]
+        public List<ScoreReason> Reasons { get; set; }
+    }
+
+    public class ScoreResponse : ScoreResponseBase
+    {
+        [JsonProperty("latest_label")]
+        public LatestLabel LatestLabel { get; set; }
     }
 
     public class DictionaryWithAbuseTypeKeyConverter : JsonConverter

--- a/src/SiftScienceNet/SiftScienceClient.cs
+++ b/src/SiftScienceNet/SiftScienceClient.cs
@@ -34,6 +34,7 @@ namespace SiftScienceNet
         Task<ResponseStatus> LinkSessionToUser(string userId, string sessionId, bool returnScore = false);
         Task<ResponseStatus> Label(string userId, bool isBad, AbuseType abuseType, string description = "", string analyst = "", string source = "");
         Task<ScoreResponse> GetSiftScore(string userId);
+        Task<LegacyScoreResponse> GetSiftLegacyScore(string userId);
     }
 
     /// <summary>
@@ -369,5 +370,25 @@ namespace SiftScienceNet
 
         #endregion
 
+        #region LegacyScore
+
+        public async Task<LegacyScoreResponse> GetSiftLegacyScore(string userId)
+        {
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            HttpResponseMessage response = await client.GetAsync(string.Format(Globals.LegacyScoreEndpoint, Uri.EscapeDataString(userId), _apiKey)).ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var json = response.Content.ReadAsStringAsync().Result;
+
+                return JsonConvert.DeserializeObject<LegacyScoreResponse>(json);
+            }
+
+            return new LegacyScoreResponse { Status = (int)response.StatusCode };
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Add "GetSiftLegacyScore" endpoint to SiftScienceClient.cs

Add LegacyScoreResponse class and use it as return type for the newly added endpoint

The above changes are because of SiftScience change stated at
the next link:

https://support.siftscience.com/hc/en-us/articles/228468368-Returning-Legacy-Score-with-API-v204